### PR TITLE
Add support for gremlin-python

### DIFF
--- a/gremlin/Dockerfile
+++ b/gremlin/Dockerfile
@@ -7,10 +7,19 @@ EXPOSE 8182
 RUN yum -y install git zip unzip &&\
 		yum clean all
 
+RUN curl -o /opt/titan-1.1.0-SNAPSHOT-hadoop2.zip https://s3.amazonaws.com/bayesian-titan110/titan-1.1.0-SNAPSHOT-hadoop2.zip
+RUN curl -O https://s3.amazonaws.com/bayesian-titan110/titan-all.tgz &&\
+    tar xzf titan-all.tgz
+
 # Prep, build and install DynamoDB storage backend driver with support for titan, and install Gremlin server
 RUN git clone https://github.com/awslabs/dynamodb-titan-storage-backend.git /opt/dynamodb/dynamodb-titan-storage-backend/ &&\
     cd /opt/dynamodb/dynamodb-titan-storage-backend/ &&\
-    mvn install &&\
+    curl https://gist.githubusercontent.com/pluradj/d56c1948f4665ee7fb1bc35daeba4f92/raw/be5f639a64c8d6ac196c59eb7e6d1a1903015b17/dynamo-titan11-tp323.patch | git apply -v --index &&\
+    mvn install
+
+
+RUN cd /opt/dynamodb/dynamodb-titan-storage-backend/ &&\
+    sed -i 's#TITAN_VANILLA_SERVER_ZIP=.*#TITAN_VANILLA_SERVER_ZIP=/opt/titan-1.1.0-SNAPSHOT-hadoop2.zip#' src/test/resources/install-gremlin-server.sh &&\
     src/test/resources/install-gremlin-server.sh
 
 WORKDIR /opt/dynamodb/

--- a/gremlin/scripts/entrypoint.sh
+++ b/gremlin/scripts/entrypoint.sh
@@ -4,10 +4,12 @@ SERVER_DIR=dynamodb-titan-storage-backend/server/dynamodb-titan100-storage-backe
 PROPS=${SERVER_DIR}/conf/gremlin-server/dynamodb.properties
 GREMLIN_CONF=${SERVER_DIR}/conf/gremlin-server/gremlin-server.yaml
 GREMLIN_HOST=$HOSTNAME
+RESPONSE_TIMEOUT=100000
 
 sed -i.bckp 's#host: .*#host: '$GREMLIN_HOST'#' ${GREMLIN_CONF}
 sed -i.bckp 's#storage.dynamodb.client.credentials.class-name=.*#storage.dynamodb.client.credentials.class-name='$1'#' ${PROPS}
 sed -i.bckp 's#storage.dynamodb.client.credentials.constructor-args=.*#storage.dynamodb.client.credentials.constructor-args='$2'#' ${PROPS}
+sed -i.bckp 's#serializedResponseTimeout: .*#serializedResponseTimeout: '${RESPONSE_TIMEOUT}'#' ${GREMLIN_CONF}
 
 if [ -v aws_region ]; then
   sed -i.bckp 's#storage.dynamodb.client.endpoint=.*#storage.dynamodb.client.endpoint='$aws_region'#' ${PROPS}


### PR DESCRIPTION
This PR add support for native gremlin-python when you use websocket. 

I needed to add titan-1.1.0 and a dynamodb-storage-backend built on top of it to be able to install TinkerPop 3.2.3, so I've prebuilt them and added them as `assets/` to make build faster.

I've also increased the `serializedResponseTimeout` as queries were failing for me