### PR TITLE
Fixes Issue#20 

### DIFF
--- a/gremlin/scripts/entrypoint.sh
+++ b/gremlin/scripts/entrypoint.sh
@@ -49,6 +49,22 @@ if [ -n "$DYNAMODB_PREFIX" ]; then
     sed -i.bckp 's#storage.dynamodb.prefix=.*#storage.dynamodb.prefix='$DYNAMODB_PREFIX'#' ${PROPS}
 fi
 
+if [ -n "$WRITE_UNITS" ]; then
+    sed -i.bckp 's#storage.dynamodb.stores.edgestore.capacity-write=.*#storage.dynamodb.stores.edgestore.capacity-write='$WRITE_UNITS'#' ${PROPS}
+    sed -i.bckp 's#storage.dynamodb.stores.graphindex.capacity-write=.*#storage.dynamodb.stores.graphindex.capacity-write='$WRITE_UNITS'#' ${PROPS}
+else
+    sed -i.bckp 's#storage.dynamodb.stores.edgestore.capacity-write=.*#storage.dynamodb.stores.edgestore.capacity-write=25#' ${PROPS}
+    sed -i.bckp 's#storage.dynamodb.stores.graphindex.capacity-write=.*#storage.dynamodb.stores.graphindex.capacity-write=25#' ${PROPS}
+fi
+
+if [ -n "$READ_UNITS" ]; then
+    sed -i.bckp 's#storage.dynamodb.stores.edgestore.capacity-read=.*#storage.dynamodb.stores.edgestore.capacity-read='$READ_UNITS'#' ${PROPS}
+    sed -i.bckp 's#storage.dynamodb.stores.graphindex.capacity-read=.*#storage.dynamodb.stores.graphindex.capacity-read='$READ_UNITS'#' ${PROPS}
+else
+    sed -i.bckp 's#storage.dynamodb.stores.edgestore.capacity-read=.*#storage.dynamodb.stores.edgestore.capacity-read=25#' ${PROPS}
+    sed -i.bckp 's#storage.dynamodb.stores.graphindex.capacity-read=.*#storage.dynamodb.stores.graphindex.capacity-read=25#' ${PROPS}
+fi
+
 cd ${SERVER_DIR}
 
 exec bin/gremlin-server.sh conf/gremlin-server/gremlin-server.yaml


### PR DESCRIPTION
1. Default read and write units to 25 to save on AWS cost
2. Can be changed via configuration parameter `READ_UNITS` and `WRITE_UNITS` for production deployment