### PR TITLE
to avoid parallelMutate error

### DIFF
--- a/gremlin/scripts/entrypoint.sh
+++ b/gremlin/scripts/entrypoint.sh
@@ -14,6 +14,8 @@ echo "Proceeding with JAVA_OPTIONS=$JAVA_OPTIONS"
 
 sed -i.bckp 's#host: .*#host: '$GREMLIN_HOST'#' ${GREMLIN_CONF}
 
+sed -i.bckp 's#storage.dynamodb.native-locking=false'
+
 if [ -n "$DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME" ]; then
     sed -i.bckp 's#storage.dynamodb.client.credentials.class-name=.*#storage.dynamodb.client.credentials.class-name='${DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME}'#' ${PROPS}
 fi
@@ -65,7 +67,7 @@ else
     sed -i.bckp 's#storage.dynamodb.stores.edgestore.capacity-read=.*#storage.dynamodb.stores.edgestore.capacity-read=25#' ${PROPS}
     sed -i.bckp 's#storage.dynamodb.stores.graphindex.capacity-read=.*#storage.dynamodb.stores.graphindex.capacity-read=25#' ${PROPS}
 fi
-
+ 
 cd ${SERVER_DIR}
 
 exec bin/gremlin-server.sh conf/gremlin-server/gremlin-server.yaml

--- a/gremlin/scripts/entrypoint.sh
+++ b/gremlin/scripts/entrypoint.sh
@@ -14,7 +14,7 @@ echo "Proceeding with JAVA_OPTIONS=$JAVA_OPTIONS"
 
 sed -i.bckp 's#host: .*#host: '$GREMLIN_HOST'#' ${GREMLIN_CONF}
 
-sed -i.bckp 's#storage.dynamodb.native-locking=false'
+sed -i.bckp 's#storage.dynamodb.native-locking=.*#storage.dynamodb.native-locking=false'   ${PROPS}
 
 if [ -n "$DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME" ]; then
     sed -i.bckp 's#storage.dynamodb.client.credentials.class-name=.*#storage.dynamodb.client.credentials.class-name='${DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME}'#' ${PROPS}


### PR DESCRIPTION
As per discussion with @tuxdna, this PR includes one of the possible solutions to incorporate resource locking in dynamodb. It may avoid the parallelMutate error, which is occurring in the gremlin-http pod.

Thanks,
Saket